### PR TITLE
Fixing threshold must be numeric and non-NAN issue #5

### DIFF
--- a/util.py
+++ b/util.py
@@ -11,7 +11,7 @@ from keras import backend as K
 #------------------------------------------------------------------------------
 def init():
     random.seed(1337)
-    np.set_printoptions(threshold=np.nan) 
+    np.set_printoptions(threshold=sys.maxsize) 
     np.random.seed(1337)
     sys.setrecursionlimit(40000)
 


### PR DESCRIPTION
On one of my machine "np.set_printoptions(threshold=np.nan)" was throwing an error, this fix that.